### PR TITLE
correctly handle overloading

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+X.XX    2013-04-15  DAKKAR     Use refaddr & reftype to "do the right thing"
+	                         when comparing objects that overload
+	                         numification and stringification
 X.XX    XXXX-XX-XX  DCANTRELL  Add David Muir Sharnoff's tests for
                                  really big data structures
 

--- a/lib/Data/Compare.pm
+++ b/lib/Data/Compare.pm
@@ -146,7 +146,7 @@ sub Compare {
     elsif ($refx ne $refy) { # not the same type
       $rval = 0;
     }
-    elsif ($x == $y) { # exactly the same reference
+    elsif (Scalar::Util::refaddr($x) == Scalar::Util::refaddr($y)) { # exactly the same reference
       $rval = 1;
     }
     elsif ($refx eq 'SCALAR' || $refx eq 'REF') {
@@ -186,7 +186,7 @@ sub Compare {
       $rval = 0;
     }
     else { # a package name (object blessed)
-      my ($type) = "$x" =~ m/^$refx=(\S+)\(/;
+      my $type = Scalar::Util::reftype($x);
       if ($type eq 'HASH') {
         my %x = %$x;
         my %y = %$y;

--- a/t/overload.t
+++ b/t/overload.t
@@ -1,0 +1,26 @@
+#!perl
+{
+package SpecialClass;
+use strict;use warnings;
+use overload
+    '""' => \&to_string,
+    '0+' => \&to_number,
+        fallback=>1;
+
+sub new { my ($class,%data) = @_; bless {%data},$class }
+sub to_string { return $_[0]->{str} || 'foo' }
+sub to_number { return $_[0]->{num} || 12 }
+}
+
+use strict;
+use warnings;
+use Data::Compare;
+use Test::More tests=>2;
+
+ok(!Compare(SpecialClass->new(str=>'bar'),
+            SpecialClass->new(str=>'bar',num=>15)),
+   'String overload does not fool it');
+
+ok(!Compare(SpecialClass->new(str=>'bar',num=>15),
+            SpecialClass->new(str=>'boo',num=>15)),
+   'Numeric overload does not fool it');


### PR DESCRIPTION
comparing references with '==' to check if they're the same fails if
they're blessed and overload numification or numeric comparison;
Scalar::Util::refaddr works

stringifying a blessed reference to get the underlying reference type
fails if it overloads stringification; Scalar::Util::reftype works
