### PR TITLE
Use consistent version numbering

### DIFF
--- a/lib/Data/Compare/Plugins/Scalar/Properties.pm
+++ b/lib/Data/Compare/Plugins/Scalar/Properties.pm
@@ -4,7 +4,7 @@ use strict;
 use vars qw($VERSION);
 use Data::Compare;
 
-$VERSION = 1.0;
+$VERSION = 1.25;
 
 sub register {
     return [


### PR DESCRIPTION
This is a CPAN Pull Request Challenge pull request.

This PR makes all modules share the same version number, as suggested by CPANTS.