### PR TITLE
Define perl minimum version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,6 +2,7 @@ use ExtUtils::MakeMaker qw(WriteMakefile);
 
 WriteMakefile(
   NAME         => 'Data::Compare',
+  MIN_PERL_VERSION => 5.006,
   META_MERGE => {
     license => 'other',
     resources => {
@@ -9,6 +10,7 @@ WriteMakefile(
       bugtracker => 'https://github.com/DrHyde/perl-modules-Data-Compare/issues'
     },
   },
+  BUILD_REQUIRES => { "ExtUtils::MakeMaker" => 6.48 },
   VERSION_FROM => "lib/Data/Compare.pm",
   PREREQ_PM    => {
     File::Find::Rule => 0.10,


### PR DESCRIPTION
This is a CPAN Pull Request Challenge pull request.

This PR defines the minimum requested perl version, as suggested by CPANTS.
Note that this option of EU::MM requires a "kind of" recent version of it, thus it was specified in the Makefile.