### PR TITLE
Add license metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,20 +1,21 @@
 use ExtUtils::MakeMaker qw(WriteMakefile);
 
 WriteMakefile(
-  NAME         => 'Data::Compare',
-  META_MERGE => {
-    license => ["gpl_2"],
-    resources => {
-      repository => 'https://github.com/DrHyde/perl-modules-Data-Compare',
-      bugtracker => 'https://github.com/DrHyde/perl-modules-Data-Compare/issues'
+    NAME         => 'Data::Compare',
+    META_ADD => {
+	"meta-spec" => { version => 2 },
     },
-    "meta-spec" => { version => 2 },
-  },
-  VERSION_FROM => "lib/Data/Compare.pm",
-  PREREQ_PM    => {
-    File::Find::Rule => 0.10,
-    Scalar::Util     => 0
-  },
-  clean        => { FILES => '*.bak *.old mibs/*.dump lib/*/*~' },
-  LICENSE => "artistic_1",
+    META_MERGE => {
+	license => ["artistic_1", "gpl_2"],
+	resources => {
+	    repository => 'https://github.com/DrHyde/perl-modules-Data-Compare',
+	    bugtracker => 'https://github.com/DrHyde/perl-modules-Data-Compare/issues'
+	},
+    },
+    VERSION_FROM => "lib/Data/Compare.pm",
+    PREREQ_PM    => {
+	File::Find::Rule => 0.10,
+	Scalar::Util     => 0
+    },
+    clean        => { FILES => '*.bak *.old mibs/*.dump lib/*/*~' },
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,11 +3,12 @@ use ExtUtils::MakeMaker qw(WriteMakefile);
 WriteMakefile(
   NAME         => 'Data::Compare',
   META_MERGE => {
-    license => 'other',
+    license => ["gpl_2"],
     resources => {
       repository => 'https://github.com/DrHyde/perl-modules-Data-Compare',
       bugtracker => 'https://github.com/DrHyde/perl-modules-Data-Compare/issues'
     },
+    "meta-spec" => { version => 2 },
   },
   VERSION_FROM => "lib/Data/Compare.pm",
   PREREQ_PM    => {
@@ -15,4 +16,5 @@ WriteMakefile(
     Scalar::Util     => 0
   },
   clean        => { FILES => '*.bak *.old mibs/*.dump lib/*/*~' },
+  LICENSE => "artistic_1",
 );


### PR DESCRIPTION
This is a CPAN Pull Request Challenge pull request.

This time, it defines the two licenses available. Note that although this is not the optimal way, it works: one license directly in EU::MM, the other as "meta_add".

If you do not define LICENSE, and just META_ADD, then you will get three licenses (unknown, artistic and gpl)